### PR TITLE
Replace placeholder author email and use default values

### DIFF
--- a/inc/generator.php
+++ b/inc/generator.php
@@ -110,64 +110,55 @@ class WDS_Theme_Generator {
 	 */
 	public function init() {
 
-		if ( ! isset( $_REQUEST['wds_wdunderscores_generate'], $_REQUEST['wds_wdunderscores_name'] ) ) {
+		if ( ! isset( $_REQUEST['wds_wdunderscores_generate'] ) ) {
 			return;
 		}
 
-		if ( empty( $_REQUEST['wds_wdunderscores_name'] ) ) {
-			wp_die( 'Please enter a theme name. Please go back and try again.' );
-		}
-
-		// Set defaults
-		$this->theme = array(
-			'name'         => 'Acme Inc.',
-			'slug'         => 'acme-inc',
-			'uri'          => 'https://acmeinc.com',
-			'author'       => 'WebDevStudios',
-			'author_uri'   => 'https://webdevstudios.com/',
-			'author_email' => 'contact@webdevstudios.com',
-			'dev_uri'      => 'https://acmeinc.test',
-			'description'  => 'A spiffy new theme for Acme Inc. by WebDevStudios based on wd_s.',
-			'functions'    => 'wds_acme',
-			'wpcom'        => false,
+		// Defaults.
+		$defaults = array(
+			'wds_wdunderscores_name'         => 'Acme Inc.',
+			'wds_wdunderscores_slug'         => 'acme-inc',
+			'wds_wdunderscores_theme_uri'    => 'https://acmeinc.com',
+			'wds_wdunderscores_author'       => 'WebDevStudios',
+			'wds_wdunderscores_author_uri'   => 'https://webdevstudios.com/',
+			'wds_wdunderscores_author_email' => 'contact@webdevstudios.com',
+			'wds_wdunderscores_dev_uri'      => 'https://acmeinc.test',
+			'wds_wdunderscores_description'  => 'A spiffy new theme for Acme Inc. by WebDevStudios based on wd_s.',
+			'wds_wdunderscores_functions'    => 'wds_acme',
+			'wpcom'                          => false,
 		);
 
-		$this->theme['name'] = trim( $_REQUEST['wds_wdunderscores_name'] );
+		// Hold non-empty submitted field.
+		$args = array();
+		foreach ( $defaults as $key => $value ) {
+			if ( ! isset( $_REQUEST[ $key ] ) || empty( trim( $_REQUEST[ $key ] ) ) ) {
+				continue;
+			}
+
+			$args[ $key ] = sanitize_text_field( $_REQUEST[ $key ] );
+		}
+
+		$parsed_args = wp_parse_args( $args, $defaults );
+
+		// Setup generated theme info.
+		$this->theme         = array();
+		$this->theme['name'] = $parsed_args['wds_wdunderscores_name'];
+
+		// By default, slug should be based from 'name' unless it's specifically specified.
 		$this->theme['slug'] = sanitize_title_with_dashes( $this->theme['name'] );
-		$this->theme['functions'] = trim( $_REQUEST['wds_wdunderscores_functions'] );
-		$this->theme['wpcom'] = (bool) isset( $_REQUEST['can_i_haz_wpcom'] );
-
-		if ( ! empty( $_REQUEST['wds_wdunderscores_description'] ) ) {
-			$this->theme['description'] = trim( $_REQUEST['wds_wdunderscores_description'] );
+		if ( $parsed_args['wds_wdunderscores_slug'] !== $defaults['wds_wdunderscores_slug'] ) {
+			$this->theme['slug'] = sanitize_title_with_dashes( $parsed_args['wds_wdunderscores_slug'] );
 		}
 
-		if ( ! empty( $_REQUEST['wds_wdunderscores_theme_uri'] ) ) {
-			$this->theme['uri'] = trim( $_REQUEST['wds_wdunderscores_theme_uri'] );
-		}
-
-		if ( ! empty( $_REQUEST['wds_wdunderscores_functions'] ) ) {
-			$this->theme['functions'] = preg_replace( '/\s+/', '_', $_REQUEST['wds_wdunderscores_functions'] );
-		}
-
-		if ( ! empty( $_REQUEST['wds_wdunderscores_slug'] ) ) {
-			$this->theme['slug'] = sanitize_title_with_dashes( $_REQUEST['wds_wdunderscores_slug'] );
-		}
-
-		if ( ! empty( $_REQUEST['wds_wdunderscores_author'] ) ) {
-			$this->theme['author'] = trim( $_REQUEST['wds_wdunderscores_author'] );
-		}
-
-		if ( ! empty( $_REQUEST['wds_wdunderscores_author_uri'] ) ) {
-			$this->theme['author_uri'] = trim( $_REQUEST['wds_wdunderscores_author_uri'] );
-		}
-
-		if ( ! empty( $_REQUEST['wds_wdunderscores_author_email'] ) ) {
-			$this->theme['author_email'] = trim( $_REQUEST['wds_wdunderscores_author_email'] );
-		}
-
-		if ( ! empty( $_REQUEST['wds_wdunderscores_dev_uri'] ) ) {
-			$this->theme['dev_uri'] = esc_url( $_REQUEST['wds_wdunderscores_dev_uri'] );
-		}
+		$this->theme['functions']    = $parsed_args['wds_wdunderscores_functions'];
+		$this->theme['wpcom']        = (bool) isset( $parsed_args['can_i_haz_wpcom'] );
+		$this->theme['description']  = $parsed_args['wds_wdunderscores_description'];
+		$this->theme['uri']          = $parsed_args['wds_wdunderscores_theme_uri'];
+		$this->theme['functions']    = preg_replace( '/\s+/', '_', $parsed_args['wds_wdunderscores_functions'] );
+		$this->theme['author']       = $parsed_args['wds_wdunderscores_author'];
+		$this->theme['author_uri']   = $parsed_args['wds_wdunderscores_author_uri'];
+		$this->theme['author_email'] = $parsed_args['wds_wdunderscores_author_email'];
+		$this->theme['dev_uri']      = esc_url( $parsed_args['wds_wdunderscores_dev_uri'] );
 
 		$zip = new ZipArchive;
 		$zip_filename = sprintf( '/tmp/wdunderscores-%s.zip', md5( print_r( $this->theme, true ) ) );

--- a/inc/generator.php
+++ b/inc/generator.php
@@ -79,7 +79,7 @@ class WDS_Theme_Generator {
 							<div class="field-group">
 								<label for="wdunderscores-author-email">Author Email</label>
 								<input type="text" id="wdunderscores-author-email" name="wds_wdunderscores_author_email" placeholder="Theme Author Email" />
-								<p class="description">wds@webdevstudios.com</p>
+								<p class="description">contact@webdevstudios.com</p>
 							</div>
 						</div><!-- .group-four -->
 
@@ -125,7 +125,7 @@ class WDS_Theme_Generator {
 			'uri'          => 'https://acmeinc.com',
 			'author'       => 'WebDevStudios',
 			'author_uri'   => 'https://webdevstudios.com/',
-			'author_email' => 'wds@webdevstudios.com',
+			'author_email' => 'contact@webdevstudios.com',
 			'dev_uri'      => 'https://acmeinc.test',
 			'description'  => 'A spiffy new theme for Acme Inc. by WebDevStudios based on wd_s.',
 			'functions'    => 'wds_acme',


### PR DESCRIPTION
Closes #14 and #15.

### DESCRIPTION ###
This PR replaces the placeholder author email on both the site and on the generator from `wds@webdevstudios.com` to `contact@webdevstudios.com` - See #14 

This PR also allow the form to be submitted / theme generation without requiring any field input. It will use the default values for field values not provided.

### STEPS TO VERIFY ###
1. Submit the form without filling any fields and verify that default values are used in theme generation.
1. Submit the form with some fields filled up and verify that non-filled values fallback to default and provided values are used.